### PR TITLE
close serial connection in destructor of SerialIBISMaster

### DIFF
--- a/ibis/ibis_serial.py
+++ b/ibis/ibis_serial.py
@@ -41,3 +41,6 @@ class SerialIBISMaster(IBISProtocol):
         """
         
         return self.device.read(length)
+
+    def __del__(self):
+        self.device.close()


### PR DESCRIPTION
Fixes the exception when trying to create a new instance of SerialIBISMaster after the first one is already closed.

```
>>> master = ibis.SerialIBISMaster("/dev/ttyUSB5", debug = True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/pi/.local/lib/python3.7/site-packages/ibis/ibis_serial.py", line 26, in __init__
    timeout = timeout
  File "/home/pi/.local/lib/python3.7/site-packages/serial/serialutil.py", line 240, in __init__
    self.open()
  File "/home/pi/.local/lib/python3.7/site-packages/serial/serialposix.py", line 272, in open
    self._reconfigure_port(force_update=True)
  File "/home/pi/.local/lib/python3.7/site-packages/serial/serialposix.py", line 438, in _reconfigure_port
    [iflag, oflag, cflag, lflag, ispeed, ospeed, cc])
termios.error: (22, 'Invalid argument')
```

The error is fixed by closing the previous connection on termination:
```
master = ibis.SerialIBISMaster("/dev/ttyUSB5", debug = True)
master.device.close()
```

That's why I added the close call for the serial connection to the `__del__` method of SerialIBISMaster.